### PR TITLE
 [linux] Add kernel 5.14

### DIFF
--- a/products/linuxkernel.md
+++ b/products/linuxkernel.md
@@ -45,6 +45,10 @@ releases:
     release: 2021-06-28
     eol: false
 
+  - releaseCycle: "5.14"
+    release: 2021-08-29
+    eol: false
+
 ---
 
 > The Linux kernel is a free and open-source, monolithic, modular, multitasking, Unix-like operating system kernel.


### PR DESCRIPTION
[Kernel 5.14 has been released](https://lore.kernel.org/lkml/CAHk-=wh75ELUu99yPkPNt+R166CK=-M4eoV+F62tW3TVgB7=4g@mail.gmail.com/T/#u).

Not an LTS release, I think a good approach to have on keeping kernels listed on the page is whether kernel.org keeps them listed. Usually the previous kernel (if not LTS) will keep receiving updates for up to a month, then is listed as EOL on the page for another month until its removal, this seems like a logical process for us aswell.